### PR TITLE
Add S3 sync for models and datasets

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -6,6 +6,7 @@ name = "pypi"
 [packages]
 python-dotenv = "*"
 huggingface-hub = {extras = ["cli"], version = "*"}
+boto3 = "*"
 
 [dev-packages]
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "350b630ef6bc24ec1ae7bd687dcb1f1b22c48994ee1742d8a60832a667ac98a6"
+            "sha256": "a9ba6d9083e30ed09c41a7e277b3dddedada36a4aaa05173a640038494de5eb8"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -26,141 +26,60 @@
         },
         "anyio": {
             "hashes": [
-                "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708",
-                "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc"
+                "sha256:4e5533c5b8ff0a24f5d7a176cbe6877129cd183893f66b537f8f227d10527d72",
+                "sha256:8d648a3544c1a700e3ff78615cd679e4c5c3f149904287e73687b2596963629e"
             ],
             "markers": "python_version >= '3.10'",
-            "version": "==4.13.0"
+            "version": "==4.14.1"
+        },
+        "boto3": {
+            "hashes": [
+                "sha256:42942dde254673abcbc9e6e60017c88341a4f49d99d24e1f2e290fb38138c26f",
+                "sha256:587d7ee92a12e440ad12b0e7f11f3358f0c4d65b19f64726efc94aaf194aff28"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.10'",
+            "version": "==1.43.36"
+        },
+        "botocore": {
+            "hashes": [
+                "sha256:3c65fdc39ed01d8dfde1e961b34038aed03c459f8ddf80717a12ac006475e49d",
+                "sha256:4cae47d1b2d426316b85a0087d9e69e048f13bc003b5177d74639fe9dfd28205"
+            ],
+            "markers": "python_version >= '3.10'",
+            "version": "==1.43.36"
         },
         "certifi": {
             "hashes": [
-                "sha256:3cb2210c8f88ba2318d29b0388d1023c8492ff72ecdde4ebdaddbb13a31b1c4a",
-                "sha256:8d455352a37b71bf76a79caa83a3d6c25afee4a385d632127b6afb3963f1c580"
+                "sha256:024c88eeec92ca068db80f02b8b07c9cef7b9fe261d1d535abfd5abd6f6af432",
+                "sha256:2227dcbaafe0d2f59279d1762ddddc37783ed4354594f194ffc31d20f41fc3db"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==2026.4.22"
-        },
-        "charset-normalizer": {
-            "hashes": [
-                "sha256:005fa3432484527f9732ebd315da8da8001593e2cf46a3d817669f062c3d9ed4",
-                "sha256:046595208aae0120559a67693ecc65dd75d46f7bf687f159127046628178dc45",
-                "sha256:0c29de6a1a95f24b9a1aa7aefd27d2487263f00dfd55a77719b530788f75cff7",
-                "sha256:0c8c57f84ccfc871a48a47321cfa49ae1df56cd1d965a09abe84066f6853b9c0",
-                "sha256:0f5d9ed7f254402c9e7d35d2f5972c9bbea9040e99cd2861bd77dc68263277c7",
-                "sha256:18dd2e350387c87dabe711b86f83c9c78af772c748904d372ade190b5c7c9d4d",
-                "sha256:1b1bde144d98e446b056ef98e59c256e9294f6b74d7af6846bf5ffdafd687a7d",
-                "sha256:1c95a1e2902a8b722868587c0e1184ad5c55631de5afc0eb96bc4b0d738092c0",
-                "sha256:1cad5f45b3146325bb38d6855642f6fd609c3f7cad4dbaf75549bf3b904d3184",
-                "sha256:21b2899062867b0e1fde9b724f8aecb1af14f2778d69aacd1a5a1853a597a5db",
-                "sha256:24498ba8ed6c2e0b56d4acbf83f2d989720a93b41d712ebd4f4979660db4417b",
-                "sha256:25a23ea5c7edc53e0f29bae2c44fcb5a1aa10591aae107f2a2b2583a9c5cbc64",
-                "sha256:289200a18fa698949d2b39c671c2cc7a24d44096784e76614899a7ccf2574b7b",
-                "sha256:28a1005facc94196e1fb3e82a3d442a9d9110b8434fc1ded7a24a2983c9888d8",
-                "sha256:32fc0341d72e0f73f80acb0a2c94216bd704f4f0bce10aedea38f30502b271ff",
-                "sha256:36b31da18b8890a76ec181c3cf44326bf2c48e36d393ca1b72b3f484113ea344",
-                "sha256:3c21d4fca343c805a52c0c78edc01e3477f6dd1ad7c47653241cf2a206d4fc58",
-                "sha256:3fddb7e2c84ac87ac3a947cb4e66d143ca5863ef48e4a5ecb83bd48619e4634e",
-                "sha256:43e0933a0eff183ee85833f341ec567c0980dae57c464d8a508e1b2ceb336471",
-                "sha256:4a476b06fbcf359ad25d34a057b7219281286ae2477cc5ff5e3f70a246971148",
-                "sha256:4e594135de17ab3866138f496755f302b72157d115086d100c3f19370839dd3a",
-                "sha256:50bf98d5e563b83cc29471fa114366e6806bc06bc7a25fd59641e41445327836",
-                "sha256:5a9979887252a82fefd3d3ed2a8e3b937a7a809f65dcb1e068b090e165bbe99e",
-                "sha256:5baececa9ecba31eff645232d59845c07aa030f0c81ee70184a90d35099a0e63",
-                "sha256:5bf4545e3b962767e5c06fe1738f951f77d27967cb2caa64c28be7c4563e162c",
-                "sha256:6333b3aa5a12c26b2a4d4e7335a28f1475e0e5e17d69d55141ee3cab736f66d1",
-                "sha256:65c981bdbd3f57670af8b59777cbfae75364b483fa8a9f420f08094531d54a01",
-                "sha256:68a328e5f55ec37c57f19ebb1fdc56a248db2e3e9ad769919a58672958e8f366",
-                "sha256:6a0289e4589e8bdfef02a80478f1dfcb14f0ab696b5a00e1f4b8a14a307a3c58",
-                "sha256:6b66f92b17849b85cad91259efc341dce9c1af48e2173bf38a85c6329f1033e5",
-                "sha256:6c9379d65defcab82d07b2a9dfbfc2e95bc8fe0ebb1b176a3190230a3ef0e07c",
-                "sha256:6fc1f5b51fa4cecaa18f2bd7a003f3dd039dd615cd69a2afd6d3b19aed6775f2",
-                "sha256:70f7172939fdf8790425ba31915bfbe8335030f05b9913d7ae00a87d4395620a",
-                "sha256:721c76e84fe669be19c5791da68232ca2e05ba5185575086e384352e2c309597",
-                "sha256:7222ffd5e4de8e57e03ce2cef95a4c43c98fcb72ad86909abdfc2c17d227fc1b",
-                "sha256:75d10d37a47afee94919c4fab4c22b9bc2a8bf7d4f46f87363bcf0573f3ff4f5",
-                "sha256:76af085e67e56c8816c3ccf256ebd136def2ed9654525348cfa744b6802b69eb",
-                "sha256:770cab594ecf99ae64c236bc9ee3439c3f46be49796e265ce0cc8bc17b10294f",
-                "sha256:7a6ab32f7210554a96cd9e33abe3ddd86732beeafc7a28e9955cdf22ffadbab0",
-                "sha256:7c48ed483eb946e6c04ccbe02c6b4d1d48e51944b6db70f697e089c193404941",
-                "sha256:7f56930ab0abd1c45cd15be65cc741c28b1c9a34876ce8c17a2fa107810c0af0",
-                "sha256:8075c35cd58273fee266c58c0c9b670947c19df5fb98e7b66710e04ad4e9ff86",
-                "sha256:8272b73e1c5603666618805fe821edba66892e2870058c94c53147602eab29c7",
-                "sha256:82d8fd25b7f4675d0c47cf95b594d4e7b158aca33b76aa63d07186e13c0e0ab7",
-                "sha256:844da2b5728b5ce0e32d863af26f32b5ce61bc4273a9c720a9f3aa9df73b1455",
-                "sha256:8755483f3c00d6c9a77f490c17e6ab0c8729e39e6390328e42521ef175380ae6",
-                "sha256:915f3849a011c1f593ab99092f3cecfcb4d65d8feb4a64cf1bf2d22074dc0ec4",
-                "sha256:926ca93accd5d36ccdabd803392ddc3e03e6d4cd1cf17deff3b989ab8e9dbcf0",
-                "sha256:982bb1e8b4ffda883b3d0a521e23abcd6fd17418f6d2c4118d257a10199c0ce3",
-                "sha256:98f862da73774290f251b9df8d11161b6cf25b599a66baf087c1ffe340e9bfd1",
-                "sha256:9cbfacf36cb0ec2897ce0ebc5d08ca44213af24265bd56eca54bee7923c48fd6",
-                "sha256:a370b3e078e418187da8c3674eddb9d983ec09445c99a3a263c2011993522981",
-                "sha256:a955b438e62efdf7e0b7b52a64dc5c3396e2634baa62471768a64bc2adb73d5c",
-                "sha256:aa6af9e7d59f9c12b33ae4e9450619cf2488e2bbe9b44030905877f0b2324980",
-                "sha256:aa88ca0b1932e93f2d961bf3addbb2db902198dca337d88c89e1559e066e7645",
-                "sha256:aaeeb6a479c7667fbe1099af9617c83aaca22182d6cf8c53966491a0f1b7ffb7",
-                "sha256:aaf27faa992bfee0264dc1f03f4c75e9fcdda66a519db6b957a3f826e285cf12",
-                "sha256:b2680962a4848b3c4f155dc2ee64505a9c57186d0d56b43123b17ca3de18f0fa",
-                "sha256:b2d318c11350e10662026ad0eb71bb51c7812fc8590825304ae0bdd4ac283acd",
-                "sha256:b33de11b92e9f75a2b545d6e9b6f37e398d86c3e9e9653c4864eb7e89c5773ef",
-                "sha256:b3daeac64d5b371dea99714f08ffc2c208522ec6b06fbc7866a450dd446f5c0f",
-                "sha256:be1e352acbe3c78727a16a455126d9ff83ea2dfdcbc83148d2982305a04714c2",
-                "sha256:bee093bf902e1d8fc0ac143c88902c3dfc8941f7ea1d6a8dd2bcb786d33db03d",
-                "sha256:c72fbbe68c6f32f251bdc08b8611c7b3060612236e960ef848e0a517ddbe76c5",
-                "sha256:c9e36a97bee9b86ef9a1cf7bb96747eb7a15c2f22bdb5b516434b00f2a599f02",
-                "sha256:cddf7bd982eaa998934a91f69d182aec997c6c468898efe6679af88283b498d3",
-                "sha256:cf713fe9a71ef6fd5adf7a79670135081cd4431c2943864757f0fa3a65b1fafd",
-                "sha256:d11b54acf878eef558599658b0ffca78138c8c3655cf4f3a4a673c437e67732e",
-                "sha256:d41c4d287cfc69060fa91cae9683eacffad989f1a10811995fa309df656ec214",
-                "sha256:d524ba3f1581b35c03cb42beebab4a13e6cdad7b36246bd22541fa585a56cccd",
-                "sha256:daac4765328a919a805fa5e2720f3e94767abd632ae410a9062dff5412bae65a",
-                "sha256:db4c7bf0e07fc3b7d89ac2a5880a6a8062056801b83ff56d8464b70f65482b6c",
-                "sha256:dc7039885fa1baf9be153a0626e337aa7ec8bf96b0128605fb0d77788ddc1681",
-                "sha256:dccab8d5fa1ef9bfba0590ecf4d46df048d18ffe3eec01eeb73a42e0d9e7a8ba",
-                "sha256:dedb8adb91d11846ee08bec4c8236c8549ac721c245678282dcb06b221aab59f",
-                "sha256:e45ba65510e2647721e35323d6ef54c7974959f6081b58d4ef5d87c60c84919a",
-                "sha256:e53efc7c7cee4c1e70661e2e112ca46a575f90ed9ae3fef200f2a25e954f4b28",
-                "sha256:e635b87f01ebc977342e2697d05b56632f5f879a4f15955dfe8cef2448b51691",
-                "sha256:e70e990b2137b29dc5564715de1e12701815dacc1d056308e2b17e9095372a82",
-                "sha256:e8082b26888e2f8b36a042a58307d5b917ef2b1cacab921ad3323ef91901c71a",
-                "sha256:e8323a9b031aa0393768b87f04b4164a40037fb2a3c11ac06a03ffecd3618027",
-                "sha256:e92fca20c46e9f5e1bb485887d074918b13543b1c2a1185e69bb8d17ab6236a7",
-                "sha256:eb30abc20df9ab0814b5a2524f23d75dcf83cde762c161917a2b4b7b55b1e518",
-                "sha256:eba9904b0f38a143592d9fc0e19e2df0fa2e41c3c3745554761c5f6447eedabf",
-                "sha256:ef8de666d6179b009dce7bcb2ad4c4a779f113f12caf8dc77f0162c29d20490b",
-                "sha256:efd387a49825780ff861998cd959767800d54f8308936b21025326de4b5a42b9",
-                "sha256:f0aa37f3c979cf2546b73e8222bbfa3dc07a641585340179d768068e3455e544",
-                "sha256:f4074c5a429281bf056ddd4c5d3b740ebca4d43ffffe2ef4bf4d2d05114299da",
-                "sha256:f69a27e45c43520f5487f27627059b64aaf160415589230992cec34c5e18a509",
-                "sha256:fb707f3e15060adf5b7ada797624a6c6e0138e2a26baa089df64c68ee98e040f",
-                "sha256:fcbe676a55d7445b22c10967bceaaf0ee69407fbe0ece4d032b6eb8d4565982a",
-                "sha256:fdb20a30fe1175ecabed17cbf7812f7b804b8a315a25f24678bcdf120a90077f"
-            ],
-            "markers": "python_version >= '3.7'",
-            "version": "==3.4.2"
+            "version": "==2026.6.17"
         },
         "click": {
             "hashes": [
-                "sha256:40c50b7c6c6adac2823d411041ec84f3f103f1b280d5e9ce0d7f998995832f81",
-                "sha256:638f1338fe1235c8f4e008e4a8a254fb5c5fbdcbb40ece3c9142ebb78e792973"
+                "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6",
+                "sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76"
             ],
             "markers": "python_version >= '3.10'",
-            "version": "==8.4.0"
+            "version": "==8.4.2"
         },
         "filelock": {
             "hashes": [
-                "sha256:69974355e960702e789734cb4871f884ea6fe50bd8404051a3530bc07809cf90",
-                "sha256:96f5f6344709aa1572bbf631c640e4ebeeb519e08da902c39a001882f30ac258"
+                "sha256:10cdb3656fc44541cdf30652a93fb10ec6b05325620eb316bd26893e4201538a",
+                "sha256:dac1648087d5115554850d113e7dd8c83ab2d38e3435dde2d4f163847e57b767"
             ],
             "markers": "python_version >= '3.10'",
-            "version": "==3.29.0"
+            "version": "==3.29.4"
         },
         "fsspec": {
             "hashes": [
-                "sha256:11ef7bb35dab8a394fde6e608221d5cf3e8499401c249bebaeaad760a1a8dec2",
-                "sha256:301d8ac70ae90ef3ad05dcf94d6c3754a097f9b5fe4667d2787aa359ec7df7e4"
+                "sha256:02e0b71817df9b2169dc30a16832045764def1191b43dcff5bb85bdee212d2a1",
+                "sha256:f5bac145310fe30e16e1471bd6840b2d990d609e872251d7e674241822abf01a"
             ],
             "markers": "python_version >= '3.10'",
-            "version": "==2026.4.0"
+            "version": "==2026.6.0"
         },
         "h11": {
             "hashes": [
@@ -172,34 +91,34 @@
         },
         "hf-xet": {
             "hashes": [
-                "sha256:1e60df5a42e9bed8628b6416af2cba4cba57ae9f02de226a06b020d98e1aab18",
-                "sha256:2806c7c17b4d23f8d88f7c4814f838c3b6150773fe339c20af23e1cfaf2797e4",
-                "sha256:2baea1b0b989e5c152fe81425f7745ddc8901280ba3d97c98d8cdece7b706c60",
-                "sha256:3531b1823a0e6d77d80f9ed15ca0e00f0d115094f8ac033d5cae88f4564cc949",
-                "sha256:4b35549ce62601b84da4ff9b24d970032ace3d4430f52d91bcbb26c901d6c690",
-                "sha256:526345b3ed45f374f6317349df489167606736c876241ba984105afe7fd4839d",
-                "sha256:5906bf7718d3636dc13402914736abe723492cb730f744834f5f5b67d3a12702",
-                "sha256:5f3dc2248fc01cc0a00cd392ab497f1ca373fcbc7e3f2da1f452480b384e839e",
-                "sha256:73a0dae8c71de3b0633a45c73f4a4a5ed09e94b43441d82981a781d4f12baa42",
-                "sha256:786d28e2eb8315d5035544b9d137b4a842d600c434bb91bf7d0d953cce906ad4",
-                "sha256:7d70fe2ce97b9db73b9c9b9c81fe3693640aec83416a966c446afea54acfae3c",
-                "sha256:872d5601e6deea30d15865ede55d29eac6daf5a534ab417b99b6ef6b076dd96c",
-                "sha256:8dbcbab554c9ef158ef2c991545c3e970ddd8cc7acdcd0a78c5a41095dab4ded",
-                "sha256:9929561f5abf4581c8ea79587881dfef6b8abb2a0d8a51915936fc2a614f4e73",
-                "sha256:9a0ee58cd18d5ea799f7ed11290bbccbe56bdd8b1d97ca74b9cc49a3945d7a3b",
-                "sha256:a60290ec57e9b71767fba7c3645ddafdd0759974b540441510c629c6db6db24a",
-                "sha256:b285cea1b5bab46b758772716ba8d6854a1a0310fed1c249d678a8b38601e5a0",
-                "sha256:b6c9df403040248c76d808d3e047d64db2d923bae593eb244c41e425cf6cd7be",
-                "sha256:c799d49f1a5544a0ef7591c0ee75e0d6b93d6f56dc7a4979f59f7518d2872216",
-                "sha256:cf7b2dc6f31a4ea754bb50f74cde482dcf5d366d184076d8530b9872787f3761",
-                "sha256:dad0dc84e941b8ba3c860659fe1fdc35c049d47cce293f003287757e971a8f56",
-                "sha256:e0fb0a34d9f406eed88233e829a67ec016bec5af19e480eac65a233ea289a948",
-                "sha256:e5de0f6deada0dada870bb376a11bcd1f08abf3a968a6d118f33e72d1b1eb480",
-                "sha256:f7b7bbae318e583a86fb21e5a4a175d6721d628a2874f4bd022d0e660c32a682",
-                "sha256:fd6e5a9b0fdac4ed03ed45ef79254a655b1aaab514a02202617fbf643f5fdf7a"
+                "sha256:0c97106032ef70467b4f6bc2d0ccc266d7613ee076afc56516c502f87ce1c4a6",
+                "sha256:3474760d10e3bb6f92ff3f024fcb00c0b3e4001e9b035c7483e49a5dd17aa70f",
+                "sha256:4f561cbbb92f80960772059864b7fb07eae879adde1b2e781ec6f86f6ac26c59",
+                "sha256:51ef4500dab3764b41135ee1381a4b62ce56fc54d4c92b719b59e597d6df5bf6",
+                "sha256:6071d5ccb4d8d2cbd5fea5cc798da4f0ba3f44e25369591c4e89a4987050e61d",
+                "sha256:6208adb15d192b90e4c2ad2a27ed864359b2cb0f2494eb6d7c7f3699ac02e2bf",
+                "sha256:6762d89b9e3267dfd502b29b2a327b4525f33b17e7b509a78d94e2151a30ce30",
+                "sha256:6abd35c3221eff63836618ddfb954dcf84798603f71d8e33e3ed7b04acfdbe6e",
+                "sha256:6f7a04a8ad962422e225bc49fbbac99dc1806764b1f3e54dbd154bffa7593947",
+                "sha256:8298485c1e36e7e67cbd01eeb1376619b7af43d4f1ec245caae306f890a8a32d",
+                "sha256:892e3a3a3aecc12aded8b93cf4f9cd059282c7de0732f7d55026f3abdf474350",
+                "sha256:93d090b57b211133f6c0dab0205ef5cb6d89162979ba75a74845045cc3063b8e",
+                "sha256:94e761bbd266bf4c03cee73753916062665ce8365aa40ed321f45afcb934b41e",
+                "sha256:97f212a88d14bbf573619a74b7fecb238de77d08fc702e54dec6f78276ca3283",
+                "sha256:a93df2039190502835b1db8cd7e178b0b7b889fe9ab51299d5ced26e0dd879a4",
+                "sha256:bf67e6ed10260cef62e852789dc91ebb03f382d5bdc4b1dbeb64763ea275e7d6",
+                "sha256:c6b6cd08ca095058780b50b8ce4d6cbf6787bcf27841705d58a9d32246e3e47a",
+                "sha256:d48199c2bf4f8df0adc55d31d1368b6ec0e4d4f45bc86b08038089c23db0bed8",
+                "sha256:dbf48c0d02cf0b2e568944330c60d9120c272dabe013bd892d48e25bc6797577",
+                "sha256:e1af0de8ca6f190d4294a28b88023db64a1e2d1d719cab044baf75bec569e7a9",
+                "sha256:e78e4e5192ad2b674c2e1160b651cb9134db974f8ae1835bdfbfb0166b894a43",
+                "sha256:e7dbb40617410f432182d918e37c12303fe6700fd6aa6c5964e30a535a4461d6",
+                "sha256:f4ad3ebd4c32dd2b27099d69dc7b2df821e30767e46fb6ee6a0713778243b8ff",
+                "sha256:f61e3665892a6c8c5e765395838b8ddf36185da835253d4bc4509a81e49fb342",
+                "sha256:f7b3002f95d1c13e24bcb4537baa8f0eb3838957067c91bb4959bc004a6435f5"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==1.5.0"
+            "version": "==1.5.1"
         },
         "httpcore": {
             "hashes": [
@@ -218,28 +137,31 @@
             "version": "==0.28.1"
         },
         "huggingface-hub": {
-            "hashes": [
-                "sha256:28abfdddda3927fd4de6a63cf26ab012498a2c24dae52baf150c5c6edf98a1d5",
-                "sha256:a4a59af04cbc41a3fe3fec429b171ef994ef8c971eda10136746f408dd4e3744"
+            "extras": [
+                "cli"
             ],
-            "index": "pypi",
+            "hashes": [
+                "sha256:a44f222cd8f2f7c2eade30b5e7a04cac984a3235fa61ea87a0a5a31db77d561f",
+                "sha256:eadaa3678c512c82aea69e8675d90a184861e68de32f1105668628b4dce0e7cd"
+            ],
             "markers": "python_full_version >= '3.10.0'",
-            "version": "==1.15.0"
+            "version": "==1.21.0"
         },
         "idna": {
             "hashes": [
-                "sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8",
-                "sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc"
+                "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2",
+                "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848"
             ],
-            "markers": "python_version >= '3.8'",
-            "version": "==3.15"
+            "markers": "python_version >= '3.9'",
+            "version": "==3.18"
         },
-        "inquirerpy": {
+        "jmespath": {
             "hashes": [
-                "sha256:89d2ada0111f337483cb41ae31073108b2ec1e618a49d7110b0d7ade89fc197e",
-                "sha256:c65fdfbac1fa00e3ee4fb10679f4d3ed7a012abf4833910e63c295827fe2a7d4"
+                "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d",
+                "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64"
             ],
-            "version": "==0.3.4"
+            "markers": "python_version >= '3.9'",
+            "version": "==1.1.0"
         },
         "markdown-it-py": {
             "hashes": [
@@ -265,22 +187,6 @@
             "markers": "python_version >= '3.8'",
             "version": "==26.2"
         },
-        "pfzy": {
-            "hashes": [
-                "sha256:5f50d5b2b3207fa72e7ec0ef08372ef652685470974a107d0d4999fc5a903a96",
-                "sha256:717ea765dd10b63618e7298b2d98efd819e0b30cd5905c9707223dceeb94b3f1"
-            ],
-            "markers": "python_version >= '3.7' and python_version < '4.0'",
-            "version": "==0.3.4"
-        },
-        "prompt-toolkit": {
-            "hashes": [
-                "sha256:3527b7af26106cbc65a040bcc84839a3566ec1b051bb0bfe953631e704b0ff7d",
-                "sha256:a11a29cb3bf0a28a387fe5122cdb649816a957cd9261dcedf8c9f1fef33eacf6"
-            ],
-            "markers": "python_full_version >= '3.7.0'",
-            "version": "==3.0.43"
-        },
         "pygments": {
             "hashes": [
                 "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f",
@@ -288,6 +194,14 @@
             ],
             "markers": "python_version >= '3.9'",
             "version": "==2.20.0"
+        },
+        "python-dateutil": {
+            "hashes": [
+                "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3",
+                "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
+            "version": "==2.9.0.post0"
         },
         "python-dotenv": {
             "hashes": [
@@ -377,14 +291,6 @@
             "markers": "python_version >= '3.8'",
             "version": "==6.0.3"
         },
-        "requests": {
-            "hashes": [
-                "sha256:27babd3cda2a6d50b30443204ee89830707d396671944c998b5975b031ac2b2c",
-                "sha256:27d0316682c8a29834d3264820024b62a36942083d52caf2f14c0591336d3422"
-            ],
-            "markers": "python_version >= '3.8'",
-            "version": "==2.32.4"
-        },
         "rich": {
             "hashes": [
                 "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb",
@@ -392,6 +298,14 @@
             ],
             "markers": "python_full_version >= '3.9.0'",
             "version": "==15.0.0"
+        },
+        "s3transfer": {
+            "hashes": [
+                "sha256:777cc2415536f1debadb5c2ef7779275d0fc0fe0e042411cdd6caebeb2685262",
+                "sha256:ce436931687addc4c1712d52d40b32f53e88315723f107ffa20ba82b05a0f685"
+            ],
+            "markers": "python_version >= '3.10'",
+            "version": "==0.19.0"
         },
         "shellingham": {
             "hashes": [
@@ -401,13 +315,21 @@
             "markers": "python_version >= '3.7'",
             "version": "==1.5.4"
         },
+        "six": {
+            "hashes": [
+                "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274",
+                "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
+            "version": "==1.17.0"
+        },
         "tqdm": {
             "hashes": [
-                "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb",
-                "sha256:ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf"
+                "sha256:00dfa48452b6b6cfae3dd9885636c23d3422d1ec97c66d96818cbd5e0821d482",
+                "sha256:39832cc2def2789a6f29df83f172db7416cea70052c0907a57801c5f2fdccb03"
             ],
-            "markers": "python_version >= '3.7'",
-            "version": "==4.67.3"
+            "markers": "python_version >= '3.8'",
+            "version": "==4.68.3"
         },
         "typer": {
             "hashes": [
@@ -416,14 +338,6 @@
             ],
             "markers": "python_version >= '3.10'",
             "version": "==0.25.1"
-        },
-        "typer-slim": {
-            "hashes": [
-                "sha256:9fc6607b3c6c20f5c33ea9590cbeb17848667c51feee27d9e314a579ab07d1a3",
-                "sha256:f42a9b7571a12b97dddf364745d29f12221865acef7a2680065f9bb29c7dc89d"
-            ],
-            "markers": "python_version >= '3.8'",
-            "version": "==0.20.0"
         },
         "typing-extensions": {
             "hashes": [
@@ -438,16 +352,8 @@
                 "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c",
                 "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897"
             ],
-            "index": "pypi",
             "markers": "python_version >= '3.10'",
             "version": "==2.7.0"
-        },
-        "wcwidth": {
-            "hashes": [
-                "sha256:3da69048e4540d84af32131829ff948f1e022c1c6bdb8d6102117aac784f6859",
-                "sha256:72ea0c06399eb286d978fdedb6923a9eb47e1c486ce63e9b4e64fc18303972b5"
-            ],
-            "version": "==0.2.13"
         }
     },
     "develop": {}

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ A Python package for managing HuggingFace models and datasets with built-in secu
 
 - **Easy Model Management**: Download GGUF and other models from HuggingFace Hub
 - **Dataset Management**: Batch download datasets from HuggingFace Hub
+- **S3 Sync**: Upload downloaded models and datasets to Amazon S3 for use in AWS (SageMaker, EC2, EKS)
 - **Configuration-Based**: Use JSON files to define what to download
 - **Security First**: Built-in security features including path validation, token masking, and sensitive data filtering
 - **Comprehensive Logging**: Structured logging with sensitive data redaction
@@ -26,13 +27,23 @@ pip install -e .
 
 # Or install normally
 pip install .
+
+# Include S3 sync support (installs boto3)
+pip install ".[s3]"
 ```
 
 ### Using pip (once published)
 
 ```bash
 pip install huggingface-tools
+
+# With S3 sync support
+pip install "huggingface-tools[s3]"
 ```
+
+> **Note:** S3 sync requires `boto3`. It is an optional dependency installed
+> via the `[s3]` extra. The download commands work without it; only the
+> `sync-s3` subcommand and `--sync-s3` flags need it.
 
 ## Configuration
 
@@ -48,7 +59,19 @@ DATASET_FILE_LIST=datasets.json
 
 # Optional: HuggingFace token for gated/private models
 HF_TOKEN=your_huggingface_token_here
+
+# Optional: S3 sync defaults (used by sync-s3 and --sync-s3)
+S3_BUCKET=my-models-bucket
+S3_PREFIX=huggingface/
+AWS_REGION=us-east-1
+# S3_ENDPOINT_URL=https://s3.us-east-1.amazonaws.com  # only for S3-compatible stores
 ```
+
+> **AWS credentials are never read from this package.** S3 sync uses the
+> standard boto3 credential chain: environment variables
+> (`AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `AWS_SESSION_TOKEN`), the
+> shared credentials file (`~/.aws/credentials`), or an attached IAM role.
+> Do not put AWS secret keys in `.env`; prefer an IAM role or named profile.
 
 ### Models Configuration (`models.json`)
 
@@ -120,6 +143,74 @@ huggingface-tools download-datasets --max-workers 16
 huggingface-tools --help
 huggingface-tools download-models --help
 huggingface-tools download-datasets --help
+huggingface-tools sync-s3 --help
+```
+
+### Syncing to S3
+
+Push locally downloaded models and datasets to an S3 bucket so they can be
+consumed from AWS. The sync skips files that already exist with a matching
+size, so re-running is cheap and incremental.
+
+```bash
+# Sync the local MODEL_HOME directory to S3 (bucket/prefix from env)
+huggingface-tools sync-s3
+
+# Sync an explicit directory to a specific bucket and prefix
+huggingface-tools sync-s3 --local-dir /data/models --s3-bucket my-models-bucket --s3-prefix huggingface/
+
+# Force re-upload of everything
+huggingface-tools sync-s3 --s3-force
+
+# Sync to an S3-compatible store in a specific region
+huggingface-tools sync-s3 --s3-bucket my-bucket --s3-region us-west-2 --s3-endpoint-url https://s3.us-west-2.amazonaws.com
+```
+
+#### Download and sync in one step
+
+Both download commands accept the same S3 options. Add `--sync-s3` to upload
+the results to S3 immediately after a successful download:
+
+```bash
+# Download models, then sync them to S3
+huggingface-tools download-models --sync-s3 --s3-bucket my-models-bucket --s3-prefix models/
+
+# Download datasets, then sync them to S3 (using env defaults for bucket/prefix)
+huggingface-tools download-datasets --sync-s3
+```
+
+**S3 options** (available on `sync-s3`, `download-models`, and `download-datasets`):
+
+| Option | Env var | Description |
+| --- | --- | --- |
+| `--s3-bucket` | `S3_BUCKET` | Target S3 bucket name |
+| `--s3-prefix` | `S3_PREFIX` | Key prefix within the bucket |
+| `--s3-region` | `AWS_REGION` | AWS region for the S3 client |
+| `--s3-endpoint-url` | `S3_ENDPOINT_URL` | Custom endpoint for S3-compatible stores |
+| `--s3-force` | - | Re-upload files even if they already exist |
+| `--sync-s3` | - | (download commands only) Sync after download |
+| `--local-dir` | `MODEL_HOME` | (`sync-s3` only) Directory to upload |
+
+#### Required IAM permissions
+
+The principal running the sync needs write access to the target bucket/prefix:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": ["s3:PutObject", "s3:GetObject"],
+      "Resource": "arn:aws:s3:::my-models-bucket/huggingface/*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": ["s3:ListBucket"],
+      "Resource": "arn:aws:s3:::my-models-bucket"
+    }
+  ]
+}
 ```
 
 ### As a Python Module
@@ -158,6 +249,19 @@ stats = download_datasets(
 )
 
 print(f"Downloaded: {stats['downloaded']}, Skipped: {stats['skipped']}")
+
+# Sync a local directory to S3
+from huggingface_tools.s3_sync import sync_to_s3
+
+stats = sync_to_s3(
+    local_dir=Path("/data/models"),
+    bucket="my-models-bucket",
+    prefix="huggingface/",
+    region="us-east-1",
+    force=False,
+)
+
+print(f"Uploaded: {stats['uploaded']}, Skipped: {stats['skipped']}, Failed: {stats['failed']}")
 ```
 
 ## Security Best Practices
@@ -187,6 +291,11 @@ This package implements several security best practices:
 - Comprehensive error handling for network issues
 - Authentication errors are clearly reported
 - Unexpected errors are logged with full context
+
+### 6. S3 Sync Safety
+- Bucket names are validated against AWS naming rules
+- Key prefixes are sanitized to prevent path traversal in object keys
+- AWS credentials are resolved via the boto3 chain (env, profile, IAM role) and never stored by the package
 
 ## Logging
 
@@ -263,6 +372,7 @@ huggingface-tools/
 │   ├── cli.py                # CLI implementation
 │   ├── models.py             # Model download functionality
 │   ├── datasets.py           # Dataset download functionality
+│   ├── s3_sync.py            # S3 sync/upload functionality
 │   ├── logging_config.py     # Logging configuration
 │   └── security.py           # Security utilities
 ├── scripts/                  # Legacy scripts (kept for reference)

--- a/huggingface_tools/cli.py
+++ b/huggingface_tools/cli.py
@@ -15,6 +15,52 @@ from huggingface_tools import __version__
 from huggingface_tools.logging_config import setup_logging, get_logger
 from huggingface_tools.models import download_models, ModelDownloadError
 from huggingface_tools.datasets import download_datasets, DatasetDownloadError
+from huggingface_tools.s3_sync import sync_to_s3, S3SyncError
+
+
+def add_s3_sync_arguments(parser: argparse.ArgumentParser) -> None:
+    """
+    Add S3 sync options to a download subparser.
+
+    These options let a download command upload its results to S3 in the
+    same invocation. The sync runs only when --sync-s3 is provided.
+
+    Args:
+        parser: Subparser to attach the arguments to
+    """
+    group = parser.add_argument_group('S3 sync options')
+
+    group.add_argument(
+        '--sync-s3',
+        action='store_true',
+        help='After downloading, sync the local directory to an S3 bucket'
+    )
+
+    group.add_argument(
+        '--s3-bucket',
+        help='Target S3 bucket name (default: from S3_BUCKET env var)'
+    )
+
+    group.add_argument(
+        '--s3-prefix',
+        help='Key prefix within the bucket (default: from S3_PREFIX env var)'
+    )
+
+    group.add_argument(
+        '--s3-region',
+        help='AWS region for the S3 client (default: from AWS_REGION env var)'
+    )
+
+    group.add_argument(
+        '--s3-endpoint-url',
+        help='Custom S3 endpoint URL for S3-compatible stores'
+    )
+
+    group.add_argument(
+        '--s3-force',
+        action='store_true',
+        help='Re-upload files to S3 even if they already exist'
+    )
 
 
 def create_parser() -> argparse.ArgumentParser:
@@ -104,6 +150,8 @@ For more information, visit: https://github.com/yourusername/huggingface-tools
         help='Force re-download even if files already exist'
     )
 
+    add_s3_sync_arguments(models_parser)
+
     # Subcommand: download-datasets
     datasets_parser = subparsers.add_parser(
         'download-datasets',
@@ -134,6 +182,52 @@ For more information, visit: https://github.com/yourusername/huggingface-tools
         type=int,
         default=8,
         help='Number of concurrent download threads (default: 8)'
+    )
+
+    add_s3_sync_arguments(datasets_parser)
+
+    # Subcommand: sync-s3
+    sync_parser = subparsers.add_parser(
+        'sync-s3',
+        help='Sync a local directory of models/datasets to S3',
+        description=(
+            'Upload the contents of a local directory to an S3 bucket so '
+            'the models and datasets can be consumed from AWS. Uses the '
+            'standard boto3 credential chain (env vars, shared credentials '
+            'file, or IAM role).'
+        )
+    )
+
+    sync_parser.add_argument(
+        '--local-dir',
+        type=Path,
+        help='Local directory to upload (default: from MODEL_HOME env var)'
+    )
+
+    sync_parser.add_argument(
+        '--s3-bucket',
+        help='Target S3 bucket name (default: from S3_BUCKET env var)'
+    )
+
+    sync_parser.add_argument(
+        '--s3-prefix',
+        help='Key prefix within the bucket (default: from S3_PREFIX env var)'
+    )
+
+    sync_parser.add_argument(
+        '--s3-region',
+        help='AWS region for the S3 client (default: from AWS_REGION env var)'
+    )
+
+    sync_parser.add_argument(
+        '--s3-endpoint-url',
+        help='Custom S3 endpoint URL for S3-compatible stores'
+    )
+
+    sync_parser.add_argument(
+        '--s3-force',
+        action='store_true',
+        help='Re-upload files even if they already exist in the bucket'
     )
 
     return parser
@@ -169,12 +263,18 @@ def handle_download_models(args: argparse.Namespace, logger) -> int:
         print(f"Failed:            {stats['failed']}")
         print("="*50)
 
+        download_rc = 0
         if stats['failed'] > 0:
             logger.warning("Some models failed to download. Check logs for details.")
-            return 1
+            download_rc = 1
+        else:
+            logger.info("Model download completed successfully")
 
-        logger.info("Model download completed successfully")
-        return 0
+        if getattr(args, 'sync_s3', False):
+            sync_rc = run_s3_sync(args, logger, local_dir=args.model_home)
+            return download_rc or sync_rc
+
+        return download_rc
 
     except ModelDownloadError as e:
         logger.error(f"Model download failed: {e}")
@@ -215,12 +315,18 @@ def handle_download_datasets(args: argparse.Namespace, logger) -> int:
         print(f"Failed:            {stats['failed']}")
         print("="*50)
 
+        download_rc = 0
         if stats['failed'] > 0:
             logger.warning("Some datasets failed to download. Check logs for details.")
-            return 1
+            download_rc = 1
+        else:
+            logger.info("Dataset download completed successfully")
 
-        logger.info("Dataset download completed successfully")
-        return 0
+        if getattr(args, 'sync_s3', False):
+            sync_rc = run_s3_sync(args, logger, local_dir=args.dataset_home)
+            return download_rc or sync_rc
+
+        return download_rc
 
     except DatasetDownloadError as e:
         logger.error(f"Dataset download failed: {e}")
@@ -228,6 +334,68 @@ def handle_download_datasets(args: argparse.Namespace, logger) -> int:
     except Exception as e:
         logger.error(f"Unexpected error: {e}", exc_info=True)
         return 1
+
+
+def run_s3_sync(args: argparse.Namespace, logger, local_dir: Optional[Path] = None) -> int:
+    """
+    Run an S3 sync using the S3 options on the parsed args.
+
+    Args:
+        args: Parsed command-line arguments (must have s3_* attributes)
+        logger: Logger instance
+        local_dir: Directory to upload (overrides args/env when provided)
+
+    Returns:
+        Exit code (0 for success, 1 for failure)
+    """
+    try:
+        logger.info("Starting S3 sync")
+
+        stats = sync_to_s3(
+            local_dir=local_dir or getattr(args, 'local_dir', None),
+            bucket=args.s3_bucket,
+            prefix=args.s3_prefix,
+            region=args.s3_region,
+            endpoint_url=args.s3_endpoint_url,
+            force=args.s3_force,
+        )
+
+        print("\n" + "="*50)
+        print("S3 SYNC SUMMARY")
+        print("="*50)
+        print(f"Total files:       {stats['total']}")
+        print(f"Uploaded:          {stats['uploaded']}")
+        print(f"Skipped:           {stats['skipped']}")
+        print(f"Failed:            {stats['failed']}")
+        print("="*50)
+
+        if stats['failed'] > 0:
+            logger.warning("Some files failed to sync. Check logs for details.")
+            return 1
+
+        logger.info("S3 sync completed successfully")
+        return 0
+
+    except S3SyncError as e:
+        logger.error(f"S3 sync failed: {e}")
+        return 1
+    except Exception as e:
+        logger.error(f"Unexpected error during S3 sync: {e}", exc_info=True)
+        return 1
+
+
+def handle_sync_s3(args: argparse.Namespace, logger) -> int:
+    """
+    Handle the sync-s3 subcommand.
+
+    Args:
+        args: Parsed command-line arguments
+        logger: Logger instance
+
+    Returns:
+        Exit code (0 for success, 1 for failure)
+    """
+    return run_s3_sync(args, logger)
 
 
 def main(argv: Optional[list] = None) -> int:
@@ -266,6 +434,8 @@ def main(argv: Optional[list] = None) -> int:
         return handle_download_models(args, logger)
     elif args.command == 'download-datasets':
         return handle_download_datasets(args, logger)
+    elif args.command == 'sync-s3':
+        return handle_sync_s3(args, logger)
     else:
         logger.error(f"Unknown command: {args.command}")
         parser.print_help()

--- a/huggingface_tools/s3_sync.py
+++ b/huggingface_tools/s3_sync.py
@@ -1,0 +1,238 @@
+"""
+S3 sync functionality for huggingface-tools.
+
+Uploads (syncs) locally downloaded models and datasets to an Amazon S3
+bucket so they can be consumed from AWS (e.g. SageMaker, EC2, EKS).
+
+Uses the standard boto3 credential resolution chain (environment
+variables, shared credentials file, IAM role, etc.). Credentials are
+never read from or written to the package itself.
+"""
+
+from pathlib import Path
+from typing import Dict, Optional
+
+try:
+    import boto3
+    from boto3.s3.transfer import TransferConfig
+    from botocore.exceptions import BotoCoreError, ClientError
+    _BOTO3_AVAILABLE = True
+except ImportError:  # pragma: no cover - exercised only without boto3 installed
+    _BOTO3_AVAILABLE = False
+    boto3 = None  # type: ignore[assignment]
+    TransferConfig = None  # type: ignore[assignment,misc]
+    BotoCoreError = ClientError = Exception  # type: ignore[assignment,misc]
+
+from huggingface_tools.logging_config import get_logger
+from huggingface_tools.security import (
+    validate_path,
+    validate_s3_bucket_name,
+    sanitize_s3_prefix,
+    get_secure_env_var,
+)
+
+logger = get_logger(__name__)
+
+# Multipart threshold/chunk size tuned for large model/dataset files.
+_MULTIPART_THRESHOLD = 64 * 1024**2  # 64 MB
+_MULTIPART_CHUNKSIZE = 64 * 1024**2  # 64 MB
+
+
+class S3SyncError(Exception):
+    """Raised when an S3 sync operation fails."""
+    pass
+
+
+def _require_boto3() -> None:
+    """Raise a helpful error if boto3 is not installed."""
+    if not _BOTO3_AVAILABLE:
+        raise S3SyncError(
+            "boto3 is required for S3 sync. Install it with: "
+            "pip install 'huggingface-tools[s3]' or pip install boto3"
+        )
+
+
+def _build_s3_key(prefix: str, relative_path: Path) -> str:
+    """
+    Build an S3 object key from a prefix and a relative file path.
+
+    Uses forward slashes regardless of host OS so keys are consistent.
+    """
+    rel = '/'.join(relative_path.parts)
+    return f"{prefix}{rel}"
+
+
+def _should_upload(
+    s3_client,
+    bucket: str,
+    key: str,
+    local_size: int,
+    force: bool,
+) -> bool:
+    """
+    Decide whether a local file needs uploading.
+
+    Skips upload when an object with a matching size already exists in the
+    bucket (unless force=True). Size is a cheap, deterministic check; HF
+    files are content-addressed so a size match is a strong signal.
+    """
+    if force:
+        return True
+
+    try:
+        head = s3_client.head_object(Bucket=bucket, Key=key)
+        if head.get('ContentLength') == local_size:
+            return False
+        return True
+    except ClientError as e:
+        error_code = e.response.get('Error', {}).get('Code', '')
+        if error_code in ('404', 'NoSuchKey', 'NotFound'):
+            return True
+        # Any other error (e.g. 403) should surface to the caller.
+        raise
+
+
+def sync_directory_to_s3(
+    local_dir: Path,
+    bucket: str,
+    prefix: str = '',
+    region: Optional[str] = None,
+    endpoint_url: Optional[str] = None,
+    force: bool = False,
+) -> Dict[str, int]:
+    """
+    Sync (upload) the contents of a local directory to an S3 bucket.
+
+    Args:
+        local_dir: Local directory to upload
+        bucket: Target S3 bucket name
+        prefix: Key prefix within the bucket (acts as a "folder")
+        region: AWS region for the S3 client (default: from env/AWS config)
+        endpoint_url: Custom S3 endpoint (for S3-compatible stores)
+        force: If True, re-upload files even if they already exist
+
+    Returns:
+        Dictionary with sync statistics (total, uploaded, skipped, failed)
+
+    Raises:
+        S3SyncError: If the bucket name is invalid or the directory is missing
+    """
+    _require_boto3()
+
+    if not validate_s3_bucket_name(bucket):
+        raise S3SyncError(f"Invalid S3 bucket name: {bucket}")
+
+    local_dir = validate_path(local_dir, must_exist=True)
+    if not local_dir.is_dir():
+        raise S3SyncError(f"Local path is not a directory: {local_dir}")
+
+    prefix = sanitize_s3_prefix(prefix)
+
+    s3_client = boto3.client(
+        's3',
+        region_name=region or get_secure_env_var('AWS_REGION'),
+        endpoint_url=endpoint_url or get_secure_env_var('S3_ENDPOINT_URL'),
+    )
+
+    transfer_config = TransferConfig(
+        multipart_threshold=_MULTIPART_THRESHOLD,
+        multipart_chunksize=_MULTIPART_CHUNKSIZE,
+        use_threads=True,
+    )
+
+    stats = {'total': 0, 'uploaded': 0, 'skipped': 0, 'failed': 0}
+
+    logger.info(
+        f"Syncing '{local_dir}' to s3://{bucket}/{prefix} "
+        f"(force={force})"
+    )
+
+    for file_path in sorted(local_dir.rglob('*')):
+        if not file_path.is_file():
+            continue
+
+        stats['total'] += 1
+        relative_path = file_path.relative_to(local_dir)
+        key = _build_s3_key(prefix, relative_path)
+        local_size = file_path.stat().st_size
+
+        try:
+            if not _should_upload(s3_client, bucket, key, local_size, force):
+                logger.info(f"Skipping (already in sync): s3://{bucket}/{key}")
+                stats['skipped'] += 1
+                continue
+
+            logger.info(f"Uploading {file_path} -> s3://{bucket}/{key}")
+            s3_client.upload_file(
+                Filename=str(file_path),
+                Bucket=bucket,
+                Key=key,
+                Config=transfer_config,
+            )
+            stats['uploaded'] += 1
+
+        except (BotoCoreError, ClientError) as e:
+            logger.error(f"Failed to upload {file_path} to s3://{bucket}/{key}: {e}")
+            stats['failed'] += 1
+            # Continue with remaining files.
+
+    logger.info(
+        f"S3 sync complete. Total: {stats['total']}, "
+        f"Uploaded: {stats['uploaded']}, "
+        f"Skipped: {stats['skipped']}, "
+        f"Failed: {stats['failed']}"
+    )
+
+    return stats
+
+
+def sync_to_s3(
+    local_dir: Optional[Path] = None,
+    bucket: Optional[str] = None,
+    prefix: Optional[str] = None,
+    region: Optional[str] = None,
+    endpoint_url: Optional[str] = None,
+    force: bool = False,
+) -> Dict[str, int]:
+    """
+    Sync a local directory to S3, resolving defaults from environment.
+
+    Falls back to these environment variables when arguments are omitted:
+      - local_dir : MODEL_HOME
+      - bucket    : S3_BUCKET
+      - prefix    : S3_PREFIX
+      - region    : AWS_REGION
+
+    Args:
+        local_dir: Local directory to upload (default: from MODEL_HOME)
+        bucket: Target S3 bucket (default: from S3_BUCKET)
+        prefix: Key prefix (default: from S3_PREFIX)
+        region: AWS region (default: from AWS_REGION)
+        endpoint_url: Custom S3 endpoint (default: from S3_ENDPOINT_URL)
+        force: If True, re-upload files even if they already exist
+
+    Returns:
+        Dictionary with sync statistics
+
+    Raises:
+        S3SyncError: If required configuration is missing
+    """
+    _require_boto3()
+
+    if local_dir is None:
+        local_dir = Path(str(get_secure_env_var('MODEL_HOME', required=True)))
+
+    if bucket is None:
+        bucket = str(get_secure_env_var('S3_BUCKET', required=True))
+
+    if prefix is None:
+        prefix = get_secure_env_var('S3_PREFIX', default='') or ''
+
+    return sync_directory_to_s3(
+        local_dir=local_dir,
+        bucket=bucket,
+        prefix=prefix,
+        region=region,
+        endpoint_url=endpoint_url,
+        force=force,
+    )

--- a/huggingface_tools/security.py
+++ b/huggingface_tools/security.py
@@ -107,6 +107,63 @@ def validate_huggingface_repo_id(repo_id: str) -> bool:
     return True
 
 
+def validate_s3_bucket_name(bucket: str) -> bool:
+    """
+    Validate an S3 bucket name against AWS naming rules.
+
+    Args:
+        bucket: Bucket name to validate
+
+    Returns:
+        True if valid, False otherwise
+    """
+    # AWS rules: 3-63 chars, lowercase letters/digits/hyphens/dots,
+    # must start and end with a letter or digit, no consecutive dots,
+    # not formatted as an IP address.
+    if not (3 <= len(bucket) <= 63):
+        logger.warning(f"Invalid S3 bucket name length: {bucket}")
+        return False
+
+    if not re.match(r'^[a-z0-9][a-z0-9.-]*[a-z0-9]$', bucket):
+        logger.warning(f"Invalid S3 bucket name format: {bucket}")
+        return False
+
+    if '..' in bucket:
+        logger.warning(f"Invalid S3 bucket name (consecutive dots): {bucket}")
+        return False
+
+    if re.match(r'^\d{1,3}(\.\d{1,3}){3}$', bucket):
+        logger.warning(f"S3 bucket name must not be an IP address: {bucket}")
+        return False
+
+    return True
+
+
+def sanitize_s3_prefix(prefix: str) -> str:
+    """
+    Normalize an S3 key prefix.
+
+    Strips leading slashes and collapses path traversal markers so the
+    prefix cannot escape its intended location in the bucket.
+
+    Args:
+        prefix: Raw prefix string
+
+    Returns:
+        Normalized prefix (no leading slash, single trailing slash if non-empty)
+    """
+    # Drop null bytes and leading slashes; reject traversal segments.
+    prefix = prefix.replace('\x00', '').lstrip('/')
+
+    parts = [p for p in prefix.split('/') if p not in ('', '.', '..')]
+    normalized = '/'.join(parts)
+
+    if normalized:
+        normalized += '/'
+
+    return normalized
+
+
 def sanitize_filename(filename: str) -> str:
     """
     Sanitize a filename to prevent directory traversal and other attacks.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,9 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+s3 = [
+    "boto3>=1.34.0",
+]
 dev = [
     "pytest>=7.0.0",
     "pytest-cov>=4.0.0",


### PR DESCRIPTION
Closes #103

## Summary
Expand the tool to sync downloaded models/datasets to S3 for use in AWS.

- New `huggingface_tools/s3_sync.py`: incremental upload (skip by matching size, `--s3-force` to override), multipart tuning for large files, boto3 credential chain only.
- New `sync-s3` subcommand; `--sync-s3` + `--s3-*` flags on download commands to upload right after download.
- `validate_s3_bucket_name()` + `sanitize_s3_prefix()` added to `security`.
- `boto3` as optional `[s3]` extra; Pipfile + Pipfile.lock updated.
- README: usage, options table, IAM policy, credential guidance.

## Security
- AWS credentials never stored by package; resolved via boto3 chain (env/profile/IAM role).
- Bucket names validated against AWS rules; key prefixes sanitized against path traversal.

## Testing
- Bucket/prefix validators (accept + reject cases).
- Sync logic: upload -> skip-by-size -> force re-upload (fake S3 client).
- CLI parse for all subcommands + `main(['sync-s3', ...])` dispatch returns 0.

Note: no unit tests added to the suite yet (repo has no `tests/` dir). Recommend a follow-up issue to add `tests/test_s3_sync.py` with moto.