### PR TITLE
chore: group Dependabot updates monthly [skip ci]

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,24 +1,23 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
-
 version: 2
-updates:
-  - package-ecosystem: "pip" # See documentation for possible values
-    directory: "/" # Location of package manifests
-    schedule:
-      interval: "daily"
-  # - package-ecosystem: "github-actions" # See documentation for possible values
-  #   directory: "/" # Location of package manifests
-  #   schedule:
-  #     interval: "daily"
-  # - package-ecosystem: "docker" # See documentation for possible values
-  #   directory: "/" # Location of package manifests
-  #   schedule:
-  #     interval: "daily"
 
-  # - package-ecosystem: "terraform" # See documentation for possible values
-  #   directory: "/" # Location of package manifests
-  #   schedule:
-  #     interval: "daily"
+multi-ecosystem-groups:
+  monthly-dependencies:
+    schedule:
+      interval: monthly
+      day: monday
+      time: "09:00"
+      timezone: America/Los_Angeles
+    labels:
+      - dependencies
+
+updates:
+  - package-ecosystem: pip
+    directory: /
+    patterns: ["*"]
+    multi-ecosystem-group: monthly-dependencies
+    groups:
+      pip-security:
+        applies-to: security-updates
+        patterns: ["*"]
+    commit-message:
+      prefix: deps


### PR DESCRIPTION
## Summary
- Configures Dependabot updates to run monthly on Monday mornings Pacific time
- Groups normal dependency updates into the monthly-dependencies batch
- Groups security updates per ecosystem so Dependabot stops creating one PR per package

## CI
Commit includes `[skip ci]` because the GitHub Actions budget is currently exhausted.

This is part of cleaning up the stale individual Dependabot PRs and moving back to grouped/monthly updates.